### PR TITLE
Allow typing test access without login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,9 +25,9 @@ const App: React.FC = () => {
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/about" element={<About />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/typetest" element={<TypeTest />} />
 
           <Route element={<PrivateRoute />}>
-            <Route path="/typetest" element={<TypeTest />} />
             <Route path="/profile" element={<Profile />} />
           </Route>
         </Routes>

--- a/client/src/components/Navbar/Navbar.test.tsx
+++ b/client/src/components/Navbar/Navbar.test.tsx
@@ -27,7 +27,9 @@ describe("Navbar tests", () => {
       </BrowserRouter>
     );
 
-    expect(screen.getByText(/Type/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Type/i, { selector: "span" })
+    ).toBeInTheDocument();
     expect(screen.getByText(/Tester/i)).toBeInTheDocument();
   });
 
@@ -41,6 +43,7 @@ describe("Navbar tests", () => {
     );
 
     expect(screen.getByText(/Leaderboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Type Test/i)).toBeInTheDocument();
     expect(screen.getByText(/Register/i)).toBeInTheDocument();
     expect(screen.getByText(/Login/i)).toBeInTheDocument();
   });

--- a/client/src/components/Navbar/Navbar.tsx
+++ b/client/src/components/Navbar/Navbar.tsx
@@ -96,6 +96,14 @@ const Navbar: React.FC = () => {
                   className={styles.navItem}
                   onClick={() => setIsMenuOpen(false)}
                 >
+                  <Link to="/typetest" className={styles.navLink}>
+                    Type Test
+                  </Link>
+                </li>
+                <li
+                  className={styles.navItem}
+                  onClick={() => setIsMenuOpen(false)}
+                >
                   <Link to="/register" className={styles.navLink}>
                     Register
                   </Link>

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -5,9 +5,11 @@ import styles from "./Login.module.css";
 
 import { useAuth } from "../../context/AuthContext";
 import Loading from "../../components/Loading/Loading";
+import useSubmitScore from "../../hooks/useSubmitScore";
 
 const Login: React.FC = () => {
   const { login } = useAuth();
+  const { submitScore } = useSubmitScore();
   const [username, setUsername] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -24,7 +26,14 @@ const Login: React.FC = () => {
     try {
       const response = await login(username, password);
       if (response?.success) {
-        navigate("/");
+        const pending = localStorage.getItem("pendingScore");
+        if (pending) {
+          await submitScore(Number(pending));
+          localStorage.removeItem("pendingScore");
+          navigate("/profile");
+        } else {
+          navigate("/");
+        }
       } else {
         setErrorMessage(
           response?.message || "An unexpected error occurred. Please try again."

--- a/client/src/pages/Register/Register.test.tsx
+++ b/client/src/pages/Register/Register.test.tsx
@@ -19,7 +19,7 @@ describe("Register page tests", () => {
 
   it("should render register form", () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -35,7 +35,7 @@ describe("Register page tests", () => {
 
   it("should show error if username is too short", async () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -59,7 +59,7 @@ describe("Register page tests", () => {
   });
   it("should show error if username is too long", async () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -84,7 +84,7 @@ describe("Register page tests", () => {
 
   it("should show error if username contains non-alphanumeric characters", async () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -109,7 +109,7 @@ describe("Register page tests", () => {
 
   it("should show error if password does not meet complexity requirements", async () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -134,7 +134,7 @@ describe("Register page tests", () => {
 
   it("should show error if passwords do not match", async () => {
     const { useAuth } = require("../../context/AuthContext");
-    useAuth.mockReturnValue({ register: jest.fn() });
+    useAuth.mockReturnValue({ register: jest.fn(), login: jest.fn() });
     render(
       <BrowserRouter>
         <Register />
@@ -161,6 +161,7 @@ describe("Register page tests", () => {
     const { useAuth } = require("../../context/AuthContext");
     useAuth.mockReturnValue({
       register: jest.fn().mockResolvedValue({ success: true }),
+      login: jest.fn().mockResolvedValue({ success: true }),
     });
 
     render(
@@ -181,7 +182,7 @@ describe("Register page tests", () => {
     fireEvent.click(screen.getByRole("button", { name: /register/i }));
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/login");
+      expect(mockNavigate).toHaveBeenCalledWith("/");
     });
   });
 
@@ -191,6 +192,7 @@ describe("Register page tests", () => {
       register: jest
         .fn()
         .mockResolvedValue({ success: false, message: "Registration failed" }),
+      login: jest.fn(),
     });
 
     render(

--- a/client/src/pages/Register/Register.tsx
+++ b/client/src/pages/Register/Register.tsx
@@ -5,10 +5,12 @@ import { useAuth } from "../../context/AuthContext";
 import styles from "./Register.module.css";
 import Loading from "../../components/Loading/Loading";
 import { useValidation } from "../../hooks/useValidation";
+import useSubmitScore from "../../hooks/useSubmitScore";
 
 const Register: React.FC = () => {
-  const { register } = useAuth();
+  const { register, login } = useAuth();
   const { validationError, validateInputs } = useValidation();
+  const { submitScore } = useSubmitScore();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -29,10 +31,19 @@ const Register: React.FC = () => {
     try {
       const response = await register(username, password);
       if (response?.success) {
-        setUsername("");
-        setPassword("");
-        setConfirmPassword("");
-        navigate("/login");
+        const loginResponse = await login(username, password);
+        if (loginResponse?.success) {
+          const pending = localStorage.getItem("pendingScore");
+          if (pending) {
+            await submitScore(Number(pending));
+            localStorage.removeItem("pendingScore");
+            navigate("/profile");
+          } else {
+            navigate("/");
+          }
+        } else {
+          navigate("/login");
+        }
       } else {
         setBackendError(response?.message || "Registration failed");
         setOpenSnackbar(true);

--- a/client/src/pages/TypeTest/TypeTest.test.tsx
+++ b/client/src/pages/TypeTest/TypeTest.test.tsx
@@ -16,7 +16,7 @@ afterEach(() => {
 describe("TypeTest Component", () => {
   it("should render the initial state correctly", () => {
     const { useAuth } = require("../../context/AuthContext");
-    (useAuth as jest.Mock).mockReturnValue({ username: "user1" });
+    (useAuth as jest.Mock).mockReturnValue({ username: "user1", userId: 1 });
     render(
       <BrowserRouter>
         <TypeTest />
@@ -28,7 +28,7 @@ describe("TypeTest Component", () => {
 
   it("should start the test on input change", () => {
     const { useAuth } = require("../../context/AuthContext");
-    (useAuth as jest.Mock).mockReturnValue({ username: "user1" });
+    (useAuth as jest.Mock).mockReturnValue({ username: "user1", userId: 1 });
     render(
       <BrowserRouter>
         <TypeTest />
@@ -43,7 +43,7 @@ describe("TypeTest Component", () => {
 
   it("should toggle dictionary on button click", () => {
     const { useAuth } = require("../../context/AuthContext");
-    (useAuth as jest.Mock).mockReturnValue({ username: "user1" });
+    (useAuth as jest.Mock).mockReturnValue({ username: "user1", userId: 1 });
     render(
       <BrowserRouter>
         <TypeTest />
@@ -56,7 +56,7 @@ describe("TypeTest Component", () => {
 
   it("should update input value on change", () => {
     const { useAuth } = require("../../context/AuthContext");
-    (useAuth as jest.Mock).mockReturnValue({ username: "user1" });
+    (useAuth as jest.Mock).mockReturnValue({ username: "user1", userId: 1 });
     render(
       <BrowserRouter>
         <TypeTest />

--- a/client/src/pages/TypeTest/TypeTest.tsx
+++ b/client/src/pages/TypeTest/TypeTest.tsx
@@ -10,6 +10,8 @@ import storyWords from "../../dictionaries/story";
 import useAudio from "../../hooks/useAudio";
 import useSubmitScore from "../../hooks/useSubmitScore";
 import useTimer from "../../hooks/useTimer";
+import { useAuth } from "../../context/AuthContext";
+import { Link } from "react-router-dom";
 import styles from "./TypeTest.module.css";
 
 const initialState = {
@@ -95,6 +97,7 @@ const TypeTest: React.FC = () => {
   const { submitScore } = useSubmitScore();
   const { playAudio } = useAudio("/typewriter-click.mp3", 0.7);
   const { timer, hasStarted, isFinished } = state;
+  const { userId } = useAuth();
 
   const startTimeRef = useTimer(hasStarted, isFinished, dispatch);
   const wordsBoxRef = useRef<HTMLDivElement>(null);
@@ -207,18 +210,49 @@ const TypeTest: React.FC = () => {
               Correct words: {correctWordsCounter}
             </p>
             <p className={styles.wrongWord}>Wrong words: {wrongWordsCounter}</p>
-            <p>Hit the save button below to save your score to your profile</p>
-            {state.scoreSaved && <p>Score saved!</p>}
-            <div className={styles.buttonContainer}>
-              <button
-                onClick={() => handleScoreSubmission(wpm)}
-                disabled={state.scoreSaved || !wpm}
-              >
-                Save
-              </button>
+            {userId ? (
+              <>
+                <p>Hit the save button below to save your score to your profile</p>
+                {state.scoreSaved && <p>Score saved!</p>}
+                <div className={styles.buttonContainer}>
+                  <button
+                    onClick={() => handleScoreSubmission(wpm)}
+                    disabled={state.scoreSaved || !wpm}
+                  >
+                    Save
+                  </button>
 
-              <button onClick={resetTest}>Try Again</button>
-            </div>
+                  <button onClick={resetTest}>Try Again</button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p>
+                  Want to save your score? <br />
+                  <Link
+                    to="/login"
+                    onClick={() =>
+                      localStorage.setItem("pendingScore", wpm.toString())
+                    }
+                  >
+                    Log in
+                  </Link>{" "}
+                  or{" "}
+                  <Link
+                    to="/register"
+                    onClick={() =>
+                      localStorage.setItem("pendingScore", wpm.toString())
+                    }
+                  >
+                    create an account
+                  </Link>
+                  .
+                </p>
+                <div className={styles.buttonContainer}>
+                  <button onClick={resetTest}>Try Again</button>
+                </div>
+              </>
+            )}
           </div>
         ) : (
           <>

--- a/server/flaskr/__init__.py
+++ b/server/flaskr/__init__.py
@@ -6,12 +6,27 @@ from dotenv import load_dotenv
 
 load_dotenv(dotenv_path='.flaskenv')
 
+
+def _get_database_uri() -> str | None:
+    """Return a SQLAlchemy-compatible database URI.
+
+    Render and some external providers supply a `postgres://` URL which SQLAlchemy
+    does not recognise.  Convert it to the `postgresql://` scheme when needed so
+    the app can connect using modern Postgres drivers.
+    """
+
+    uri = os.getenv("DATABASE_URL")
+    if uri and uri.startswith("postgres://"):
+        uri = uri.replace("postgres://", "postgresql://", 1)
+    return uri
+
+
 def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
 
     app.config.from_mapping(
         SECRET_KEY=os.getenv('FLASK_SECRET_KEY', 'dev'),
-        SQLALCHEMY_DATABASE_URI=os.getenv('DATABASE_URL'),
+        SQLALCHEMY_DATABASE_URI=_get_database_uri(),
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
 


### PR DESCRIPTION
## Summary
- Allow anyone to access the typing test route
- Let guests save scores after logging in or creating an account
- Include Type Test link in guest navigation and auto-save logic after auth

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68adb04917848330b0ada96633dc4932