### PR TITLE
Add Neon-friendly DB init and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Users have the option to save their scores to a database, which can be viewed in
 
 - React (TypeScript), CSS Modules for styling and Jest for unit tests
 - Backend: Flask (Python)
-- Database: SQLite for storing user data and scores
+- Database: PostgreSQL (e.g. via Neon) for storing user data and scores
 
 ## Database
 
-The database is relatively simple and uses SQLite to set up the database, query data and manage connections.
+The database layer uses PostgreSQL accessed through SQLAlchemy. The connection URL is supplied via the `DATABASE_URL` environment variable.
 
 It contains a user table that stores an auto incrementing id, a unique username, and a hashed password. The scores table also has an auto incrementing id, associated user id, score, and a created timestamp.
 

--- a/server/README.md
+++ b/server/README.md
@@ -4,7 +4,7 @@
 
 1. Python: Ensure you have Python 3.7 or later installed. Download Python
 2. pip: The Python package installer. It comes with Python 3.x.
-3. SQLite: Install SQLite if not included with your Python installation.
+3. A PostgreSQL database such as [Neon](https://neon.tech/) with a connection URL available as the `DATABASE_URL` environment variable.
 4. Flask CLI: Ensure flask is installed (included in dependencies below).
 5. Virtual Environment: (Optional) Set up a virtual environment to avoid dependency conflicts.
 
@@ -17,7 +17,9 @@
 2. Install dependencies
    pip install -r requirements.txt
 
-3. Setup database
+3. Set the `DATABASE_URL` environment variable to your PostgreSQL connection string and initialize the database tables:
+
+   export DATABASE_URL=your_neon_database_url
    flask init-db
 
 ### Running the Backend

--- a/server/flaskr/__init__.py
+++ b/server/flaskr/__init__.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask
 from flask_cors import CORS
-from flaskr.db import db
+from flaskr.db import db, register_commands
 from dotenv import load_dotenv
 
 load_dotenv(dotenv_path='.flaskenv')
@@ -41,6 +41,7 @@ def create_app(test_config=None):
         pass
 
     db.init_app(app)
+    register_commands(app)
 
     from . import auth
     app.register_blueprint(auth.bp)

--- a/server/flaskr/db.py
+++ b/server/flaskr/db.py
@@ -1,5 +1,6 @@
-from flask import current_app, g
+from flask import g
 from flask_sqlalchemy import SQLAlchemy
+import click
 
 db = SQLAlchemy()
 
@@ -12,4 +13,18 @@ def close_db(e=None):
     db.session.remove()
 
 def init_db():
-    pass
+    """Create all database tables defined on the SQLAlchemy metadata."""
+    db.create_all()
+
+
+@click.command("init-db")
+def init_db_command():
+    """CLI command to initialize database tables."""
+    init_db()
+    click.echo("Tables created successfully!")
+
+
+def register_commands(app):
+    """Register database commands with the Flask app."""
+    app.teardown_appcontext(close_db)
+    app.cli.add_command(init_db_command)


### PR DESCRIPTION
## Summary
- initialize SQLAlchemy with DATABASE_URL for Postgres
- add `flask init-db` CLI command to create tables safely
- document DATABASE_URL configuration and CLI usage

## Testing
- `pytest -q`
- `DATABASE_URL=sqlite:///:memory: python -m flask --app flaskr init-db`

------
https://chatgpt.com/codex/tasks/task_e_68adb676e2108330a3b72ac2b14fcef7